### PR TITLE
Don't require AWS credentials

### DIFF
--- a/storages/s3.js
+++ b/storages/s3.js
@@ -6,9 +6,9 @@ const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 const S3_BUCKET = process.env.CITIZEN_AWS_S3_BUCKET;
 if (process.env.CITIZEN_STORAGE === 's3' && !S3_BUCKET) {
-  throw new Error('S3 storage requires CITIZEN_AWS_S3_BUCKET. Additionally, ensure that either ' + 
-    'AWS_PROFILE or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set. ' +
-    'If running on AWS EC2 or ECS, IAM Roles may be used.');
+  throw new Error('S3 storage requires CITIZEN_AWS_S3_BUCKET. Additionally, ensure that either '
+    + 'AWS_PROFILE or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set. '
+    + 'If running on AWS EC2 or ECS, IAM Roles may be used.');
 }
 
 s3.save = promisify(s3.putObject);


### PR DESCRIPTION
Per the AWS JavaScript SDK, credentials are automatically searched for: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

When running on AWS with an IAM Role and setting fake `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, the container doesn't start as the SDK tries to use those before falling back to searching for other credentials. Even trying to use `AWS_PROFILE` has the same effect.

`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not required for running.

Fixes #31 