### PR TITLE
Add mongoDB backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: required
 language: node_js
 node_js:
-- '8'
+- '10'
+services:
+- mongodb
 stages:
 - lint
 - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:8 as build
+FROM node:10 as build
 
 LABEL maintainer="outsideris@gmail.com"
 

--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,9 @@ If you want to test it at local, you need a tool which provides HTTPS like link:
 
 Environment variables:
 
-* `CITIZEN_DATA_PATH`: A directory to save database file. The default is `data` directory in a current working directory (absolute/relative path can be used).
+* `CITIZEN_DATABASE`: Backend provider for registry metadata. Set to `mongodb` to use MongoDB. Leaving unset will use local `nedb` file.
+* `CITIZEN_MONGO_DB_URI`: MongoDB database URI if using MongoDB backend. URI format is `mongodb://username:password@host:port/database?options...`. Default is `mongodb://localhost:27017/citizen`
+* `CITIZEN_DATA_PATH`: A directory to save database file if using local backend storage. The default is `data` directory in a current working directory (absolute/relative path can be used).
 * `CITIZEN_STORAGE` : Storage type to store module files. You can use `file` or `s3` type.
 * `CITIZEN_STORAGE_PATH`: A directory to save module files only if `CITIZEN_STORAGE` is `file` (absolute/relative path can be used).
 * `CITIZEN_AWS_S3_BUCKET``: A S3 bucket to save module files only if `CITIZEN_STORAGE` is `s3`.
@@ -86,9 +88,19 @@ $ ./bin/citizen publish
 ....
 
 === Test
+Set at least a storage path and the s3 bucket name variables for the tests to succeed.
+You need to be able to access the bucket, so you probably want to have an active aws or aws-vault profile.
+
+Run the tests:
 [source, sh]
 ....
 $ npm test
+....
+
+Run the tests with the environment variables prefixed:
+[source, sh]
+....
+$ CITIZEN_STORAGE_PATH=storage CITIZEN_AWS_S3_BUCKET=terraform-registry-modules npm test
 ....
 
 === Build distributions

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,195 +1,26 @@
-const Datastore = require('nedb');
-const uuid = require('uuid/v1');
-const { join } = require('path');
-const debug = require('debug')('citizen:server');
+/* eslint-disable global-require */
+let db;
+let save;
+let findOne;
+let findAll;
+let getVersions;
+let getLatestVersion;
+let increaseDownload;
 
-const dbDir = process.env.CITIZEN_DB_DIR || 'data';
-const dbPath = join(dbDir, 'citizen.db');
-const db = new Datastore({ filename: dbPath, autoload: true });
+if (process.env.CITIZEN_DATABASE === 'mongodb') {
+  ({
+    db, save, findOne, findAll, getVersions, getLatestVersion, increaseDownload,
+  } = require('../stores/mongodb'));
+} else {
+  ({
+    db, save, findOne, findAll, getVersions, getLatestVersion, increaseDownload,
+  } = require('../stores/nedb'));
+}
 
-const save = data => new Promise((resolve, reject) => {
-  const {
-    namespace,
-    name,
-    provider,
-    version,
-    owner,
-    location,
-    definition = {},
-  } = data;
-
-  const module = {
-    _id: `${uuid()}`,
-    owner: owner || '',
-    namespace,
-    name,
-    provider,
-    version,
-    location,
-    downloads: 0,
-    published_at: new Date(),
-    ...definition,
-  };
-
-  db.insert(module, (err, newDoc) => {
-    if (err) { return reject(err); }
-    debug('saved the module into db: %o', module);
-    return resolve(newDoc);
-  });
-});
-
-const findAll = ({
-  selector = {},
-  namespace = '',
-  provider = '',
-  offset = 0,
-  limit = 15,
-} = {}) => new Promise((resolve, reject) => {
-  const options = selector;
-
-  if (namespace) {
-    options.namespace = namespace;
-  }
-  if (provider) {
-    options.provider = provider;
-  }
-  debug('search db with %o', options);
-
-  db.find(options, (err, allDocs) => {
-    if (err) { return reject(err); }
-
-    const totalRows = allDocs.length;
-    const meta = {
-      limit: +limit,
-      currentOffset: +offset,
-      nextOffset: +offset + +limit,
-      prevOffset: +offset - +limit,
-    };
-    if (meta.prevOffset < 0) { meta.prevOffset = null; }
-    if (meta.nextOffset >= totalRows) { meta.nextOffset = null; }
-
-    return db.find(options).sort({ _id: 1 }).skip(+offset).limit(+limit)
-      .exec((error, docs) => {
-        if (error) { return reject(err); }
-
-        debug('search result from db: %o', docs);
-        return resolve({
-          meta,
-          modules: docs,
-        });
-      });
-  });
-});
-
-const getVersions = ({ namespace, name, provider } = {}) => new Promise((resolve, reject) => {
-  if (!namespace) { reject(new Error('namespace required.')); }
-  if (!name) { reject(new Error('name required.')); }
-  if (!provider) { reject(new Error('provider required.')); }
-
-  const options = {
-    namespace,
-    name,
-    provider,
-  };
-
-  debug('search versions in db with %o', options);
-  db.find(options).sort({ _id: 1 }).exec((err, docs) => {
-    if (err) { return reject(err); }
-
-    const data = docs.map(d => ({
-      version: d.version,
-      submodules: d.submodules,
-      root: d.root,
-    }));
-    debug('search versions result from db: %o', docs);
-    return resolve(data);
-  });
-});
-
-const getLatestVersion = async ({ namespace, name, provider } = {}) => new Promise(
-  (resolve, reject) => {
-    if (!namespace) { reject(new Error('namespace required.')); }
-    if (!name) { reject(new Error('name required.')); }
-    if (!provider) { reject(new Error('provider required.')); }
-
-    const options = {
-      namespace,
-      name,
-      provider,
-    };
-
-    db.find(options).sort({ version: -1 }).limit(1).exec((err, docs) => {
-      if (err) { return reject(err); }
-
-      debug('search latest version result from db: %o', docs);
-      return resolve(docs.length > 0 ? docs[0] : null);
-    });
-  },
-);
-
-const findOne = async ({
-  namespace,
-  name,
-  provider,
-  version,
-} = {}) => new Promise((resolve, reject) => {
-  if (!namespace) { reject(new Error('namespace required.')); }
-  if (!name) { reject(new Error('name required.')); }
-  if (!provider) { reject(new Error('provider required.')); }
-  if (!version) { reject(new Error('version required.')); }
-
-  const options = {
-    namespace,
-    name,
-    provider,
-    version,
-  };
-
-  debug('search a module in db with %o', options);
-  db.find(options, (err, docs) => {
-    if (err) { return reject(err); }
-
-    debug('search a module result from db: %o', docs);
-    return resolve(docs.length > 0 ? docs[0] : null);
-  });
-});
-
-const increaseDownload = async ({
-  namespace,
-  name,
-  provider,
-  version,
-} = {}) => new Promise((resolve, reject) => {
-  if (!namespace) { reject(new Error('namespace required.')); }
-  if (!name) { reject(new Error('name required.')); }
-  if (!provider) { reject(new Error('provider required.')); }
-  if (!version) { reject(new Error('version required.')); }
-
-  const options = {
-    namespace,
-    name,
-    provider,
-    version,
-  };
-
-  db.update(
-    options,
-    { $inc: { downloads: 1 } },
-    { returnUpdatedDocs: true },
-    (err, numAffected, affectedDocuments) => {
-      if (err) { return reject(err); }
-
-      return resolve(affectedDocuments);
-    },
-  );
-});
-
-module.exports = {
-  db,
-  save,
-  findOne,
-  findAll,
-  getVersions,
-  getLatestVersion,
-  increaseDownload,
-};
+exports.db = db;
+exports.save = save;
+exports.findOne = findOne;
+exports.findAll = findAll;
+exports.getVersions = getVersions;
+exports.getLatestVersion = getLatestVersion;
+exports.increaseDownload = increaseDownload;

--- a/package-lock.json
+++ b/package-lock.json
@@ -633,6 +633,11 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "bson": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -2298,7 +2303,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2319,12 +2325,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2339,17 +2347,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2466,7 +2477,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2478,6 +2490,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2492,6 +2505,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2499,12 +2513,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2523,6 +2539,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2603,7 +2620,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2615,6 +2633,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2700,7 +2719,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2736,6 +2756,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2755,6 +2776,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2798,12 +2820,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3773,6 +3797,11 @@
         "clean-deep": "^3.0.2"
       }
     },
+    "kareem": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
+      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4073,6 +4102,12 @@
         }
       }
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -4301,6 +4336,66 @@
         }
       }
     },
+    "mongodb": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.2.tgz",
+      "integrity": "sha512-xQ6apOOV+w7VFApdaJpWhYhzartpjIDFQjG0AwgJkLh7dBs7PTsq4A3Bia2QWpDohmAzTBIdQVLMqqLy0mwt3Q==",
+      "requires": {
+        "mongodb-core": "3.2.2",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "mongodb-core": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.2.tgz",
+      "integrity": "sha512-YRgC39MuzKL0uoGoRdTmV1e9m47NbMnYmuEx4IOkgWAGXPSEzRY7cwb3N0XMmrDMnD9vp7MysNyAriIIeGgIQg==",
+      "requires": {
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.5.0.tgz",
+      "integrity": "sha512-GZdhdbTXTgikInIgtxR7ODcF3+MoJTumTsKYinX3zxJcQgMVr+Y0jBuFoLJ9YtVdF2nq1ukLnhS6RHfta1ptgQ==",
+      "requires": {
+        "async": "2.6.1",
+        "bson": "~1.1.1",
+        "kareem": "2.3.0",
+        "mongodb": "3.2.2",
+        "mongodb-core": "3.2.2",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.5.1",
+        "mquery": "3.2.0",
+        "ms": "2.1.1",
+        "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -4317,6 +4412,38 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "mpath": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
+    },
+    "mquery": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.0.tgz",
+      "integrity": "sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -5407,6 +5534,11 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp-clone": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -5516,6 +5648,22 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+        }
+      }
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -5602,6 +5750,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
+      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "sax": {
       "version": "1.2.1",
@@ -5721,6 +5878,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5735,6 +5897,11 @@
       "version": "0.0.4",
       "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -5870,6 +6037,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "listr": "^0.14.2",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
+    "mongoose": "^5.5.0",
     "morgan": "^1.9.1",
     "multiparty": "^4.2.1",
     "nedb": "^1.8.0",

--- a/stores/mongodb.js
+++ b/stores/mongodb.js
@@ -1,0 +1,199 @@
+const debug = require('debug')('citizen:server');
+const mongoose = require('mongoose');
+
+const dbUri = process.env.CITIZEN_MONGO_DB_URI || 'mongodb://localhost:27017/citizen';
+
+mongoose.connect(dbUri, { useNewUrlParser: true });
+
+const Module = mongoose.model('Module', {
+  namespace: String,
+  name: String,
+  provider: String,
+  version: String,
+  owner: { type: String, default: '' },
+  location: String,
+  definition: mongoose.Schema.Types.Mixed,
+  downloads: { type: Number, default: 0 },
+  published_at: { type: Date, default: Date.now },
+});
+
+const db = Module;
+
+const save = data => new Promise((resolve, reject) => {
+  const {
+    namespace,
+    name,
+    provider,
+    version,
+    owner,
+    location,
+    definition = {},
+  } = data;
+
+  const module = new Module({
+    owner,
+    namespace,
+    name,
+    provider,
+    version,
+    location,
+    ...definition,
+  });
+
+  module.save()
+    .then((newDoc) => {
+      debug('saved the module into db: %o', module);
+      return resolve(newDoc);
+    })
+    .catch(err => reject(err));
+});
+
+const findAll = ({
+  selector = {},
+  namespace = '',
+  provider = '',
+  offset = 0,
+  limit = 15,
+} = {}) => new Promise((resolve, reject) => {
+  const options = selector;
+
+  if (namespace) {
+    options.namespace = namespace;
+  }
+  if (provider) {
+    options.provider = provider;
+  }
+  debug('search db with %o', options);
+  Module.find(options)
+    .then((allDocs) => {
+      const totalRows = allDocs.length;
+      const meta = {
+        limit: +limit,
+        currentOffset: +offset,
+        nextOffset: +offset + +limit,
+        prevOffset: +offset - +limit,
+      };
+      if (meta.prevOffset < 0) { meta.prevOffset = null; }
+      if (meta.nextOffset >= totalRows) { meta.nextOffset = null; }
+
+      return Module.find(options, null, { sort: '_id', skip: +offset, limit: +limit })
+        .then((docs) => {
+          debug('search result from db: %o', docs);
+          return resolve({
+            meta,
+            modules: docs,
+          });
+        })
+        .catch(err => reject(err));
+    })
+    .catch(err => reject(err));
+});
+
+const getVersions = ({
+  namespace,
+  name,
+  provider,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+  };
+
+  debug('search versions in db with %o', options);
+  Module.find(options, null, { sort: '_id' })
+    .then((docs) => {
+      const data = docs.map(d => ({
+        version: d.version,
+        submodules: d.submodules,
+        root: d.root,
+      }));
+      debug('search versions result from db: %o', docs);
+      return resolve(data);
+    })
+    .catch(err => reject(err));
+});
+
+const getLatestVersion = async ({
+  namespace,
+  name,
+  provider,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+  };
+
+  Module.find(options, null, { sort: '-version', limit: 1 })
+    .then((docs) => {
+      debug('search latest version result from db: %o', docs);
+      return resolve(docs.length > 0 ? docs[0] : null);
+    })
+    .catch(err => reject(err));
+});
+
+const findOne = async ({
+  namespace,
+  name,
+  provider,
+  version,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+  if (!version) { reject(new Error('version required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+    version,
+  };
+
+  debug('search a module in db with %o', options);
+  Module.find(options)
+    .then(docs => resolve(docs.length > 0 ? docs[0] : null))
+    .catch(err => reject(err));
+});
+
+const increaseDownload = async ({
+  namespace,
+  name,
+  provider,
+  version,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+  if (!version) { reject(new Error('version required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+    version,
+  };
+
+  Module.findOneAndUpdate(options, { $inc: { downloads: 1 } }, { new: true })
+    .then(doc => resolve(doc))
+    .catch(err => reject(err));
+});
+
+module.exports = {
+  db,
+  save,
+  findOne,
+  findAll,
+  getVersions,
+  getLatestVersion,
+  increaseDownload,
+};

--- a/stores/mongodb.spec.js
+++ b/stores/mongodb.spec.js
@@ -9,13 +9,13 @@ const {
   getVersions,
   getLatestVersion,
   increaseDownload,
-} = require('./store');
-const { deleteDbAll } = require('../test/helper');
+} = require('./mongodb');
+const { deleteDbAllMongo } = require('../test/helper');
 
-describe('store\'s', async () => {
+describe('mongodb store', async () => {
   describe('save()', () => {
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should store module meta', async () => {
@@ -49,7 +49,7 @@ describe('store\'s', async () => {
     });
 
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should return all modules', async () => {
@@ -125,7 +125,7 @@ describe('store\'s', async () => {
     });
 
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should return available versions', async () => {
@@ -150,7 +150,7 @@ describe('store\'s', async () => {
     });
 
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should return latest versions for a specific module', async () => {
@@ -182,7 +182,7 @@ describe('store\'s', async () => {
     });
 
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should return the specific module', async () => {
@@ -216,7 +216,7 @@ describe('store\'s', async () => {
     });
 
     after(async () => {
-      await deleteDbAll(db);
+      await deleteDbAllMongo(db);
     });
 
     it('should increase download count of the module', async () => {

--- a/stores/nedb.js
+++ b/stores/nedb.js
@@ -1,0 +1,195 @@
+const Datastore = require('nedb');
+const uuid = require('uuid/v1');
+const { join } = require('path');
+const debug = require('debug')('citizen:server');
+
+const dbDir = process.env.CITIZEN_DB_DIR || 'data';
+const dbPath = join(dbDir, 'citizen.db');
+const db = new Datastore({ filename: dbPath, autoload: true });
+
+const save = data => new Promise((resolve, reject) => {
+  const {
+    namespace,
+    name,
+    provider,
+    version,
+    owner,
+    location,
+    definition = {},
+  } = data;
+
+  const module = {
+    _id: `${uuid()}`,
+    owner: owner || '',
+    namespace,
+    name,
+    provider,
+    version,
+    location,
+    downloads: 0,
+    published_at: new Date(),
+    ...definition,
+  };
+
+  db.insert(module, (err, newDoc) => {
+    if (err) { return reject(err); }
+    debug('saved the module into db: %o', module);
+    return resolve(newDoc);
+  });
+});
+
+const findAll = ({
+  selector = {},
+  namespace = '',
+  provider = '',
+  offset = 0,
+  limit = 15,
+} = {}) => new Promise((resolve, reject) => {
+  const options = selector;
+
+  if (namespace) {
+    options.namespace = namespace;
+  }
+  if (provider) {
+    options.provider = provider;
+  }
+  debug('search db with %o', options);
+
+  db.find(options, (err, allDocs) => {
+    if (err) { return reject(err); }
+
+    const totalRows = allDocs.length;
+    const meta = {
+      limit: +limit,
+      currentOffset: +offset,
+      nextOffset: +offset + +limit,
+      prevOffset: +offset - +limit,
+    };
+    if (meta.prevOffset < 0) { meta.prevOffset = null; }
+    if (meta.nextOffset >= totalRows) { meta.nextOffset = null; }
+
+    return db.find(options).sort({ _id: 1 }).skip(+offset).limit(+limit)
+      .exec((error, docs) => {
+        if (error) { return reject(err); }
+
+        debug('search result from db: %o', docs);
+        return resolve({
+          meta,
+          modules: docs,
+        });
+      });
+  });
+});
+
+const getVersions = ({ namespace, name, provider } = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+  };
+
+  debug('search versions in db with %o', options);
+  db.find(options).sort({ _id: 1 }).exec((err, docs) => {
+    if (err) { return reject(err); }
+
+    const data = docs.map(d => ({
+      version: d.version,
+      submodules: d.submodules,
+      root: d.root,
+    }));
+    debug('search versions result from db: %o', docs);
+    return resolve(data);
+  });
+});
+
+const getLatestVersion = async ({ namespace, name, provider } = {}) => new Promise(
+  (resolve, reject) => {
+    if (!namespace) { reject(new Error('namespace required.')); }
+    if (!name) { reject(new Error('name required.')); }
+    if (!provider) { reject(new Error('provider required.')); }
+
+    const options = {
+      namespace,
+      name,
+      provider,
+    };
+
+    db.find(options).sort({ version: -1 }).limit(1).exec((err, docs) => {
+      if (err) { return reject(err); }
+
+      debug('search latest version result from db: %o', docs);
+      return resolve(docs.length > 0 ? docs[0] : null);
+    });
+  },
+);
+
+const findOne = async ({
+  namespace,
+  name,
+  provider,
+  version,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+  if (!version) { reject(new Error('version required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+    version,
+  };
+
+  debug('search a module in db with %o', options);
+  db.find(options, (err, docs) => {
+    if (err) { return reject(err); }
+
+    debug('search a module result from db: %o', docs);
+    return resolve(docs.length > 0 ? docs[0] : null);
+  });
+});
+
+const increaseDownload = async ({
+  namespace,
+  name,
+  provider,
+  version,
+} = {}) => new Promise((resolve, reject) => {
+  if (!namespace) { reject(new Error('namespace required.')); }
+  if (!name) { reject(new Error('name required.')); }
+  if (!provider) { reject(new Error('provider required.')); }
+  if (!version) { reject(new Error('version required.')); }
+
+  const options = {
+    namespace,
+    name,
+    provider,
+    version,
+  };
+
+  db.update(
+    options,
+    { $inc: { downloads: 1 } },
+    { returnUpdatedDocs: true },
+    (err, numAffected, affectedDocuments) => {
+      if (err) { return reject(err); }
+
+      return resolve(affectedDocuments);
+    },
+  );
+});
+
+module.exports = {
+  db,
+  save,
+  findOne,
+  findAll,
+  getVersions,
+  getLatestVersion,
+  increaseDownload,
+};

--- a/stores/nedb.spec.js
+++ b/stores/nedb.spec.js
@@ -1,0 +1,233 @@
+/* eslint-disable no-unused-expressions */
+const { expect } = require('chai');
+
+const {
+  db,
+  save,
+  findOne,
+  findAll,
+  getVersions,
+  getLatestVersion,
+  increaseDownload,
+} = require('./nedb');
+const { deleteDbAll } = require('../test/helper');
+
+describe('store\'s', async () => {
+  describe('save()', () => {
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should store module meta', async () => {
+      const result = await save({
+        namespace: 'store-hashicorp',
+        name: 'store-consul',
+        provider: 'store-aws',
+        version: '0.1.0',
+        owner: 'outsideris',
+        location: 'store-hashicorp/store-consul/store-aws/0.1.0/module.tar.gz',
+      });
+
+      expect(result._id).to.exist; // eslint-disable-line no-underscore-dangle
+    });
+  });
+
+  describe('findAll()', () => {
+    before(async () => {
+      await save({
+        namespace: 'store-GCP', name: 'store-lb-http', provider: 'store-google', version: '1.0.4', owner: '',
+      });
+      await save({
+        namespace: 'store-aws-modules', name: 'store-vpc', provider: 'store-aws', version: '1.2.1', owner: '',
+      });
+      await save({
+        namespace: 'store-aws-modules', name: 'store-vpc', provider: 'store-aws', version: '1.5.0', owner: '',
+      });
+      await save({
+        namespace: 'store-aws-modules', name: 'store-vpc', provider: 'store-aws', version: '1.5.1', owner: '',
+      });
+    });
+
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should return all modules', async () => {
+      const result = await findAll();
+
+      expect(result).to.have.property('modules').to.have.lengthOf(4);
+      expect(result.modules[0]).to.have.property('namespace').to.equal('store-GCP');
+    });
+
+    it('should filter modules by namespace', async () => {
+      const result = await findAll({
+        namespace: 'store-aws-modules',
+      });
+      expect(result).to.have.property('modules').to.have.lengthOf(3);
+      expect(result.modules[0]).to.have.property('namespace').to.equal('store-aws-modules');
+    });
+
+    it('should support pagination', async () => {
+      const result = await findAll({ offset: 2, limit: 2 });
+      expect(result).to.have.property('modules').to.have.lengthOf(2);
+      expect(result.modules[0]).to.have.property('namespace').to.equal('store-aws-modules');
+      expect(result.modules[0]).to.have.property('version').to.equal('1.5.0');
+    });
+
+    it('should return pagination information', async () => {
+      const result = await findAll({ offset: 2, limit: 1 });
+
+      expect(result).to.have.property('meta');
+      expect(result.meta).to.have.property('limit').to.equal(1);
+      expect(result.meta).to.have.property('currentOffset').to.equal(2);
+      expect(result.meta).to.have.property('nextOffset').to.equal(3);
+      expect(result.meta).to.have.property('prevOffset').to.equal(1);
+    });
+
+    it('should prevOffset pagination information', async () => {
+      const result = await findAll({ offset: 0, limit: 2 });
+
+      expect(result.meta).to.have.property('limit').to.equal(2);
+      expect(result.meta).to.have.property('currentOffset').to.equal(0);
+      expect(result.meta).to.have.property('nextOffset').to.equal(2);
+      expect(result.meta).to.have.property('prevOffset').to.be.null;
+    });
+
+    it('should return pagination information', async () => {
+      const result = await findAll({ offset: 2, limit: 2 });
+
+      expect(result.meta).to.have.property('limit').to.equal(2);
+      expect(result.meta).to.have.property('currentOffset').to.equal(2);
+      expect(result.meta).to.have.property('nextOffset').to.be.null;
+      expect(result.meta).to.have.property('prevOffset').to.equal(0);
+    });
+
+    it('should filter modules by provider', async () => {
+      const result = await findAll({
+        provider: 'store-aws',
+      });
+      expect(result).to.have.property('modules').to.have.lengthOf(3);
+      expect(result.modules[0]).to.have.property('namespace').to.equal('store-aws-modules');
+    });
+  });
+
+  describe('getVersions()', () => {
+    before(async () => {
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.2.1', owner: '',
+      });
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.0', owner: '',
+      });
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.1', owner: '',
+      });
+    });
+
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should return available versions', async () => {
+      const result = await getVersions({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'aws',
+      });
+
+      expect(result).to.have.lengthOf(3);
+    });
+  });
+
+  describe('getLatestVersion()', () => {
+    before(async () => {
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.0', owner: '',
+      });
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.1', owner: '',
+      });
+    });
+
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should return latest versions for a specific module', async () => {
+      const result = await getLatestVersion({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'aws',
+      });
+
+      expect(result).to.have.property('version').to.equal('1.5.1');
+    });
+
+    it('should return null when given module does not exist', async () => {
+      const result = await getLatestVersion({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'wrong-provider',
+      });
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('findOne()', () => {
+    before(async () => {
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.1', owner: '', location: 'aws-modules/vpc/aws/1.5.1/module.tar.gz',
+      });
+    });
+
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should return the specific module', async () => {
+      const result = await findOne({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'aws',
+        version: '1.5.1',
+      });
+
+      expect(result).to.have.property('version').to.equal('1.5.1');
+    });
+
+    it('should return null when given module does not exist', async () => {
+      const result = await findOne({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'aws',
+        version: '2.5.0',
+      });
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('increaseDownload()', () => {
+    before(async () => {
+      await save({
+        namespace: 'aws-modules', name: 'vpc', provider: 'aws', version: '1.5.1', owner: '', location: 'aws-modules/vpc/aws/1.5.1/module.tar.gz',
+      });
+    });
+
+    after(async () => {
+      await deleteDbAll(db);
+    });
+
+    it('should increase download count of the module', async () => {
+      const result = await increaseDownload({
+        namespace: 'aws-modules',
+        name: 'vpc',
+        provider: 'aws',
+        version: '1.5.1',
+      });
+
+      expect(result).to.have.property('downloads').to.equal(1);
+    });
+  });
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -79,4 +79,9 @@ module.exports = {
       return resolve(numRemoved);
     });
   }),
+  deleteDbAllMongo: db => new Promise((resolve, reject) => {
+    db.deleteMany({})
+      .then(doc => resolve(doc))
+      .catch(err => reject(err));
+  }),
 };


### PR DESCRIPTION
This PR incorporates a few things:
- Bump to Node v10 for build, but keep tests for Node v8
- Add switchable database module, merges in PR #37 (by @johnkeates)
- Add mongoDB backend, solves #35 

I'm no developer, so not sure if the tests are sufficient (or the best way of doing them) but working with Citizen running on AWS Fargate using mongoDB Atlas for storage, we've had no issues so far.

Would appreciate a merge-commit (rather than squash) so we can keep attribution where it's due 😄