### PR TITLE
Verify GPG signature and support ALLOWED_PUBLIC_KEY_IDS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,8 @@ Environment variables:
 * `CITIZEN_DB_DIR`: A directory to save database file if using local backend storage. The default is `data` directory in a current working directory (absolute/relative path can be used).
 * `CITIZEN_STORAGE` : Storage type to store module files. You can use `file` or `s3` type.
 * `CITIZEN_STORAGE_PATH`: A directory to save module files only if `CITIZEN_STORAGE` is `file` (absolute/relative path can be used).
-* `CITIZEN_AWS_S3_BUCKET``: A S3 bucket to save module files only if `CITIZEN_STORAGE` is `s3`.(And AWS credentials required.)
+* `CITIZEN_AWS_S3_BUCKET`: A S3 bucket to save module files only if `CITIZEN_STORAGE` is `s3`.(And AWS credentials required.)
+* `CITIZEN_ALLOWED_PUBLIC_KEY_IDS`: A comma-separated list of GPG public key IDs to allow when providers are uploaded. If unset, all public keys are allowed.
 
 == Client Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,6 +1700,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1815,6 +1826,11 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -3375,9 +3391,9 @@
       "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -4013,6 +4029,11 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4523,9 +4544,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -4608,6 +4629,14 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openpgp": {
+      "version": "5.0.0-3",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.0.0-3.tgz",
+      "integrity": "sha512-5Yzd7hjoCtR0m27yrM6+Li1RcuUPIyVJXKMfR82HJotfst5NEEQHxCyUJvDWc8SqKS53zFyTl0SlPaZ08C2PxA==",
+      "requires": {
+        "asn1.js": "^5.0.0"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "morgan": "^1.10.0",
     "multiparty": "^4.2.2",
     "nedb": "^1.8.0",
+    "openpgp": "^5.0.0-3",
     "ora": "^5.4.0",
     "pino": "^6.11.2",
     "recursive-readdir": "^2.2.1",

--- a/routes/providers.js
+++ b/routes/providers.js
@@ -114,11 +114,11 @@ router.post('/:namespace/:type/:version', (req, res, next) => {
           return next(new Error('signature could not be verified'));
       }
 
-      if (process.env.ALLOWED_PUBLIC_KEY_IDS) {
-        const allowedKeyIDs = process.env.ALLOWED_PUBLIC_KEY_IDS.split(`,`)
+      if (process.env.CITIZEN_ALLOWED_PUBLIC_KEY_IDS) {
+        const allowedKeyIDs = process.env.CITIZEN_ALLOWED_PUBLIC_KEY_IDS.split(`,`)
         console.info(`allowedKeyIDs: ${allowedKeyIDs.toString()}`)
         if (!allowedKeyIDs.some((i) => verified.signatures[0].keyID.toHex().toUpperCase() == i.toUpperCase())) {
-          return next(new Error('signature key ID not on ALLOWED_PUBLIC_KEY_IDS list'));
+          return next(new Error('signature key ID not on CITIZEN_ALLOWED_PUBLIC_KEY_IDS list'));
         }
       }
 


### PR DESCRIPTION
This allows the server operator to only allow pushing providers signed with specific public key IDs.