### PR TITLE
Allow both hyphens and underscores in Module names.

### DIFF
--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -12,7 +12,7 @@ const isValidNamespace = (namespace) => namespaceRule.test(namespace);
 
 // The Module name rule is
 // alphanumeric characters or single underscores, and cannot begin or end with a hyphen
-const moduleNameRule = /^[0-9A-Za-z](?:[0-9A-Za-z-_]{0,62}[0-9A-Za-z])?$/;
+const moduleNameRule = /[a-zA-Z0-9]+([-?_?][a-zA-Z0-9]+)+$/;
 const isValidModuleName = (name) => moduleNameRule.test(name);
 
 // The name rule is

--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -10,8 +10,16 @@ const semver = require('semver');
 const namespaceRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
 const isValidNamespace = (namespace) => namespaceRule.test(namespace);
 
+// The Module name rule is
+// alphanumeric characters or single underscores, and cannot begin or end with a hyphen
+const moduleNameRule = /^[0-9A-Za-z](?:[0-9A-Za-z-_]{0,62}[0-9A-Za-z])?$/;
+const isValidModuleName = (name) => moduleNameRule.test(name);
+
 // The name rule is
 // alphanumeric characters or single hyphens, and cannot begin or end with a hyphen
+const providerNameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
+const isValidProviderName = (name) => providerNameRule.test(name);
+
 const nameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
 const isValidName = (name) => nameRule.test(name);
 
@@ -55,7 +63,8 @@ const makeTarball = (target = __dirname, filelist = []) => new Promise((resolve,
 
 module.exports = {
   isValidNamespace,
-  isValidName,
+  isValidModuleName,
+  isValidProviderName,
   isValidType: isValidName,
   isValidVersion,
   isValidProtocol,

--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -20,9 +20,6 @@ const isValidModuleName = (name) => moduleNameRule.test(name);
 const providerNameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
 const isValidProviderName = (name) => providerNameRule.test(name);
 
-const nameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
-const isValidName = (name) => nameRule.test(name);
-
 // The version must be semantic version.
 const isValidVersion = (version) => semver.valid(version);
 
@@ -65,7 +62,7 @@ module.exports = {
   isValidNamespace,
   isValidModuleName,
   isValidProviderName,
-  isValidType: isValidName,
+  isValidType: isValidProviderName,
   isValidVersion,
   isValidProtocol,
   makeFileList,

--- a/lib/cli-helpers.spec.js
+++ b/lib/cli-helpers.spec.js
@@ -9,8 +9,8 @@ const rimraf = require('rimraf');
 
 const {
   isValidNamespace,
-  isValidName,
   isValidVersion,
+  isValidProviderName,
   isValidProtocol,
   makeFileList,
   makeTarball,
@@ -39,19 +39,19 @@ describe('cli-helpers', () => {
     });
   });
 
-  describe('isValidName()', () => {
+  describe('isValidProviderName()', () => {
     it('should check name consists of alphanumeric characters or single hyphens', () => {
-      const result = isValidName('citizen-test1');
+      const result = isValidProviderName('citizen-test1');
       expect(result).to.be.true;
     });
 
     it('should check module name which doesn\'t formatted in terraform-PROVIDER-NAME', () => {
-      const result = isValidName('terraform-aws-');
+      const result = isValidProviderName('terraform-aws-');
       expect(result).to.be.false;
     });
 
     it('should check module name which contain special characters', () => {
-      const result = isValidName('terraform-aws-cons$ul');
+      const result = isValidProviderName('terraform-aws-cons$ul');
       expect(result).to.be.false;
     });
   });

--- a/lib/module/cli.js
+++ b/lib/module/cli.js
@@ -6,7 +6,6 @@ const {
   isValidNamespace,
   isValidModuleName,
   isValidVersion,
-  isValidName,
   makeFileList,
   makeTarball,
 } = require('../cli-helpers');
@@ -33,7 +32,7 @@ module.exports = async (namespace, name, provider, version, cmd) => {
     process.exit(1);
   }
   
-  if (!isValidName(name)) {
+  if (!isValidProviderName(name)) {
     console.error('The name only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }

--- a/lib/module/cli.js
+++ b/lib/module/cli.js
@@ -4,7 +4,7 @@ const ora = require('ora');
 
 const {
   isValidNamespace,
-  isValidName,
+  isValidModuleName,
   isValidVersion,
   makeFileList,
   makeTarball,

--- a/lib/module/cli.js
+++ b/lib/module/cli.js
@@ -32,7 +32,7 @@ module.exports = async (namespace, name, provider, version, cmd) => {
     process.exit(1);
   }
 
-  if (!isValidName(name)) {
+  if (!isValidModuleName(name)) {
     console.error('The name only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }

--- a/lib/module/cli.js
+++ b/lib/module/cli.js
@@ -6,6 +6,7 @@ const {
   isValidNamespace,
   isValidModuleName,
   isValidVersion,
+  isValidName,
   makeFileList,
   makeTarball,
 } = require('../cli-helpers');
@@ -31,13 +32,13 @@ module.exports = async (namespace, name, provider, version, cmd) => {
     console.error('The namespace only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }
-
-  if (!isValidModuleName(name)) {
+  
+  if (!isValidName(name)) {
     console.error('The name only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }
-
-  if (!isValidName(provider)) {
+  
+  if (!isValidModuleName(provider)) {
     console.error('The provider only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }


### PR DESCRIPTION
In an upcoming release of Terraform, they have more clearly defined the pattern that a Module name must use in order to be detected as a registry source.

Right now, module names with dashes do not match and must instead use underscores. Unfortunately, citizen currently blocks the use of underscores in module names.

In order to facilitate both the current rules and the upcoming changes in terraform, this pull request explicitly allows both hyphens and underscores in module names while still restricting provider names to the existing rules (only hyphens and alphanumeric)