### PR TITLE
Allow multiple (single) hyphens in module names

### DIFF
--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -12,7 +12,7 @@ const isValidNamespace = (namespace) => namespaceRule.test(namespace);
 
 // The name rule is
 // alphanumeric characters or single hyphens, and cannot begin or end with a hyphen
-const nameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
+const nameRule = /^[a-zA-Z0-9]+(-?[a-zA-Z0-9])+$/;
 const isValidName = (name) => nameRule.test(name);
 
 // The version must be semantic version.

--- a/lib/cli-helpers.spec.js
+++ b/lib/cli-helpers.spec.js
@@ -45,6 +45,11 @@ describe('cli-helpers', () => {
       expect(result).to.be.true;
     });
 
+    it('should check name consists of alphanumeric characters or multiple single hyphens', () => {
+      const result = isValidName('citizen-test-with-hyphens-1');
+      expect(result).to.be.true;
+    });
+
     it('should check module name which doesn\'t formatted in terraform-PROVIDER-NAME', () => {
       const result = isValidName('terraform-aws-');
       expect(result).to.be.false;


### PR DESCRIPTION
Citizen currently only support zero or exactly one hyphen in module names. E.g.: `my-module1` will work, but `my-module-1` will not, despite it being a valid module name. Multiple single hyphens are commonly used in [TF public registry](https://registry.terraform.io/browse/modules) and being able to hyphenate longer module names is obviously very useful.