### PR TITLE
Fix intermittent corrupted payload retrieval from s3

### DIFF
--- a/storages/s3.js
+++ b/storages/s3.js
@@ -65,10 +65,10 @@ module.exports = {
     const content = await new Promise((resolve, reject) => {
       file.Body.on('data', (chunk) => chunks.push(chunk));
       file.Body.on('error', reject);
-      file.Body.on('end', () => resolve(chunks));
+      file.Body.on('end', () => resolve(Buffer.concat(chunks)));
     });
 
-    return content[0];
+    return content;
   },
   saveProvider: async (path, tarball) => {
     debug(`save the provider into ${path}.`);


### PR DESCRIPTION
I expect this code worked for very small modules, AKA those that could fit in a single chunk.

That code would have been returning only the first chunk of the array of chunks returned by the stream. We obviously need all of the chunks to perform complete download.