### PR TITLE
ci: Use built-in cache action

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,13 +45,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: 'Cache node_modules'
-        uses: actions/cache@v3
-        with:
-          path: '~/.npm'
-          key: ${{ runner.os }}-node-v${{ matrix.node }}-integration-npm-210321-${{ hashFiles('**/package-lock.json') }} }}
-          restore-keys: |
-            ${{ runner.os }}-node-v${{ matrix.node }}-integration-npm-210321-
+          cache: npm
       - name: 'Cache terraform binaries'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -63,13 +63,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: 'Cache node_modules'
-        uses: actions/cache@v3
-        with:
-          path: '~/.npm'
-          key: ${{ runner.os }}-node-v${{ matrix.node }}-210321-${{ hashFiles('**/package-lock.json') }} }}
-          restore-keys: |
-            ${{ runner.os }}-node-v${{ matrix.node }}-210321-
+          cache: npm
       - run: npm ci
       - name: Generating DB clients
         run: |


### PR DESCRIPTION
## Description

Changed workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v2` or newer has caching **built-in**.

### AS-IS

```yml
- name: Use Node.js ${{ matrix.node }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}

- name: 'Cache node_modules'
  uses: actions/cache@v3
  with:
    path: '~/.npm'
    key: ${{ runner.os }}-node-v${{ matrix.node }}-integration-npm-210321-${{ hashFiles('**/package-lock.json') }} }}
    restore-keys: |
      ${{ runner.os }}-node-v${{ matrix.node }}-integration-npm-210321-
```

### TO-BE

```yml
- name: Use Node.js ${{ matrix.node }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)